### PR TITLE
Cleanup for lat lex process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cltk"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 description = "The Classical Language Toolkit"
 license = "MIT"
 authors = ["Kyle P. Johnson <kyle@kyle-p-johnson.com>", "Patrick J. Burns <patrick@diyclassics.org>", "John Stewart <johnstewart@aya.yale.edu>", "Todd Cook <todd.g.cook@gmail.com>"]

--- a/src/cltk/corpora/grc/tlg/parse_tlg_indices.py
+++ b/src/cltk/corpora/grc/tlg/parse_tlg_indices.py
@@ -6,7 +6,6 @@ import os
 
 import regex
 
-
 from cltk.corpora.grc.tlg.author_date import AUTHOR_DATE
 from cltk.corpora.grc.tlg.author_epithet import AUTHOR_EPITHET
 from cltk.corpora.grc.tlg.author_female import AUTHOR_FEMALE

--- a/src/cltk/corpora/lat/phi/file_utils.py
+++ b/src/cltk/corpora/lat/phi/file_utils.py
@@ -3,6 +3,7 @@ PHI5 data after it has been processed by ``TLGU()``.
 """
 
 import os
+
 import regex
 
 from cltk.corpora.lat.phi.phi5_index import PHI5_INDEX, PHI5_WORKS_INDEX

--- a/src/cltk/data/fetch.py
+++ b/src/cltk/data/fetch.py
@@ -242,7 +242,7 @@ LANGUAGE_CORPORA = {
             "type": "lexicon",
             "name": "cltk_lat_lewis_elementary_lexicon",
             "origin": "https://github.com/cltk/cltk_lat_lewis_elementary_lexicon.git",
-        }
+        },
     ],
     "multilingual": [
         {
@@ -783,14 +783,3 @@ class FetchCorpus:
                         git_uri, corpus_imp_err
                     )
                     logger.error(msg)
-
-
-if __name__ == "__main__":
-    # for lang in LANGUAGE_CORPORA:
-    #     c = FetchCorpus(language=lang)
-    #     print(c.list_corpora)
-    c = FetchCorpus(language="lat")
-    print(c.list_corpora)
-    # c.import_corpus("latin_training_set_sentence_cltk")
-    # c.import_corpus("example_distributed_latin_corpus")
-    c.import_corpus("cltk_lat_lewis_elementary_lexicon", local_path="/tmp")

--- a/src/cltk/lexicon/lat.py
+++ b/src/cltk/lexicon/lat.py
@@ -60,8 +60,6 @@ class LatinLewisLexicon:
         if n_matches > 1:
             return "\n".join([self.entries[key] for key in matches])
         elif n_matches == 1:
-            print("*" * 10, lemma)
-            input()
             return self.entries[lemma]
         else:
             return ""

--- a/src/cltk/lexicon/processes.py
+++ b/src/cltk/lexicon/processes.py
@@ -14,15 +14,6 @@ from cltk.lexicon.lat import LatinLewisLexicon
 __author__ = ["Clément Besnier <clem@clementbesnier.fr>"]
 
 
-# def do_lexicon_lookup(iso_code: str, lemma: str):
-#     """Return correct lexicon lookup algo for language."""
-#     if iso_code == "lat":
-#         lex_class = LatinLewisLexicon()
-#     else:
-#         raise CLTKException(f"No lookup algorithm for language '{iso_code}'.")
-#     return lex_class.lookup
-
-
 @dataclass
 class LexiconProcess(Process):
     """To be inherited for each language's dictionary declarations.


### PR DESCRIPTION
We're close. I am getting an unexpected error when using our usual example texts (`src/cltk/ner/lat.py`, line 63). Take a look at why?

<img width="816" alt="Screen Shot 2021-02-22 at 11 26 33 PM" src="https://user-images.githubusercontent.com/1854968/108813227-6dd8bf00-7565-11eb-9f8a-910cdfd3dc13.png">

`LatinLewisLexicon.lookup()` generally works but fails for (at least) the word `nostra`:

<img width="840" alt="Screen Shot 2021-02-22 at 11 35 08 PM" src="https://user-images.githubusercontent.com/1854968/108813925-ceb4c700-7566-11eb-965f-b5b6534a6553.png">


